### PR TITLE
Build with promises

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,12 +6,22 @@ import { spawn } from "node:child_process"
  * 
  * @param {string} program 
  * @param {string[]} args 
- * @returns {ReturnType<typeof spawn>}
+ * @returns {Promise<void>}
  */
 function cmd(program, args = []) {
+    /** @type {(v?: any) => void} */
+    let resolve;
+    /** @type {(error: any) => void} */
+    let reject;
+    /** @type {Promise<void>} */
+    const promise = new Promise((f, e) => { resolve = f; reject = e; })
+
+    // NOTE: flattening the args array enables you to group related arguments for better self-documentation of the running command
+    const flatArgs = args.flat()
+
     const spawnOptions = { "shell": true };
-    console.log('CMD:', program, args.flat(), spawnOptions);
-    const p = spawn(program, args.flat(), spawnOptions); // NOTE: flattening the args array enables you to group related arguments for better self-documentation of the running command
+    console.log('CMD:', program, flatArgs, spawnOptions);
+    const p = spawn(program, flatArgs, spawnOptions);
     // @ts-ignore [stdout may be null?]
     p.stdout.on('data', (data) => process.stdout.write(data));
     // @ts-ignore [stderr may be null?]
@@ -19,40 +29,46 @@ function cmd(program, args = []) {
     p.on('close', (code) => {
         if (code !== 0) {
             console.error(program, args, 'exited with', code);
+            reject(code);
+        } else {
+            resolve();
         }
     });
-    return p;
+    return promise;
 }
 
-if (!0) cmd("tsc", []);
-if (!0) {
-    cmd("clang", ["-DSTB_IMAGE_IMPLEMENTATION", "-x", "c", "-c", "stb_image.h"]).on('close', (data) => {
-        if (data !== 0) return;
-        cmd("c3c", ["compile", "packer.c3", "common.c3", "stb_image.o"]).on('close', (data) => {
-            if (data !== 0) return;
+try {
+    if (!0) await cmd("tsc", []);
+    if (!0) {
+        await Promise.all([
+            cmd("clang", ["-DSTB_IMAGE_IMPLEMENTATION", "-x", "c", "-c", "stb_image.h"]).then(async () => {
+                await cmd("c3c", ["compile", "packer.c3", "common.c3", "stb_image.o"])
+                await cmd("c3c", [
+                    "compile",
+                    "-D", "PLATFORM_WEB",
+                    "--reloc=none",
+                    "--target", "wasm32",
+                    "-O5", "-g0", "--link-libc=no", "--no-entry",
+                    "--trust=full",
+                    "-o", "client",
+                    "-z", "--export-table",
+                    "-z", "--allow-undefined",
+                    "client.c3", "common.c3",
+                ])
+            }),
             cmd("c3c", [
                 "compile",
                 "-D", "PLATFORM_WEB",
                 "--reloc=none",
                 "--target", "wasm32",
                 "-O5", "-g0", "--link-libc=no", "--no-entry",
-                "--trust=full",
-                "-o", "client",
+                "-o", "server",
                 "-z", "--export-table",
                 "-z", "--allow-undefined",
-                "client.c3", "common.c3",
-            ])
-        });
-    })
-    cmd("c3c", [
-        "compile",
-        "-D", "PLATFORM_WEB",
-        "--reloc=none",
-        "--target", "wasm32",
-        "-O5", "-g0", "--link-libc=no", "--no-entry",
-        "-o", "server",
-        "-z", "--export-table",
-        "-z", "--allow-undefined",
-        "server.c3", "common.c3",
-    ])
+                "server.c3", "common.c3",
+            ]),
+        ])
+    }
 }
+// silence -> bad exit code already reported on close...
+catch (e) { }

--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 // @ts-check
 // Do not run this file directly. Run it via `npm run watch`. See package.json for more info.
-const { spawn } = require('child_process');
+import { spawn } from "node:child_process"
 
 /**
  * 

--- a/build.js
+++ b/build.js
@@ -40,7 +40,7 @@ function cmd(program, args = []) {
 try {
     if (!0) await cmd("tsc", []);
     if (!0) {
-        await Promise.all([
+        await Promise.allSettled([
             cmd("clang", ["-DSTB_IMAGE_IMPLEMENTATION", "-x", "c", "-c", "stb_image.h"]).then(async () => {
                 await cmd("c3c", ["compile", "packer.c3", "common.c3", "stb_image.o"])
                 await cmd("c3c", [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "raycasting",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "build": "node build.js",

--- a/serve.js
+++ b/serve.js
@@ -1,6 +1,6 @@
 // @ts-check
 // Do not run this file directly. Run it via `npm run watch`. See package.json for more info.
-const { spawn } = require('child_process');
+import { spawn } from 'child_process';
 
 /**
  * 


### PR DESCRIPTION
`cmd` In `build.js` now returns a promise.

ESM as default: makes Typescript not complaining about top-level-await as side effect.

breaking change:
By setting `"type": "module"` in `package.json`,
`.js` files are now treated as `.mjs` by default.
Append `.cjs` for CommonJS mode.
Same applies to `.ts`-files: `.mts`-behavior is default, use `.cts` to switch to CommonJS mode in typescript.