### PR TITLE
WASM Size Optimization Trick

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This script starts up http-server at http://localhost:6969/ to serve the content
 Dependencies
 - Latest commit of [C3 compiler](https://github.com/c3lang/c3c) (you need to build it from scratch)
 - Node (v20.9.0+)
+- [wabt](https://github.com/WebAssembly/wabt) (Ensure that `wasm2wat` & `wat2wasm` are in PATH)
 
 ```console
 $ node install

--- a/build.js
+++ b/build.js
@@ -2,6 +2,8 @@
 // Do not run this file directly. Run it via `npm run watch`. See package.json for more info.
 const { spawn } = require('child_process');
 
+const WASM_SIZE_OPT = true;
+
 /**
  * 
  * @param {string} program 
@@ -41,9 +43,11 @@ if (!0) {
                 "-z", "--export-table",
                 "-z", "--allow-undefined",
                 "client.c3", "common.c3",
-            ])
-        });
-    })
+            ]);
+
+	});
+    });
+    
     cmd("c3c", [
         "compile",
         "-D", "PLATFORM_WEB",
@@ -54,5 +58,24 @@ if (!0) {
         "-z", "--export-table",
         "-z", "--allow-undefined",
         "server.c3", "common.c3",
-    ])
+    ]);
+}
+
+if (WASM_SIZE_OPT) {
+    // Optimize client.wasm by converting it to WAT then back to WASM
+    cmd("wasm2wat", ["client.wasm", ">", "client.wat"])
+        .on('close', (data) => {
+	    if (data != 0) return;
+
+            cmd("wat2wasm", ["client.wat", "-o", "client.wasm"]);
+        });
+
+
+    // Optimize server.wasm by converting it to WAT then back to WASM
+    cmd("wasm2wat", ["server.wasm", ">", "server.wat"])
+        .on('close', (data) => {
+            if (data != 0) return;
+
+            cmd("wat2wasm", ["server.wat", "-o", "server.wasm"]);
+        });
 }


### PR DESCRIPTION
# TLDR;
- Updated build script to perform the following commands:
  - `$ wasm2wat client.wasm > client.wat`
  - `$ wat2wasm client.wat -o client.wasm`
  - `$ wasm2wat server.wasm > server.wat`
  - `$ wat2wasm server.wat -o server.wasm`
- Updated README to add dependency on [wabt](https://github.com/WebAssembly/wabt).

# Problem
LLVM bloats the generated wasm binary.

# Solution
While learning about WASM and WAT I noticed that if you disassemble the wasm binary using `wasm2wat`, then compile it again using `wat2wasm`, it significantly reduces the size of the generated wasm binary.
This is important for online games as smaller binaries take less time to load.

# Results
```console
# Before
$ ls -alh *wasm
-rwxr-xr-x 1 saumi saumi 172K Jan 17 00:21 client.wasm
-rwxr-xr-x 1 saumi saumi  82K Jan 17 00:21 server.wasm

# After
$ ls -alh *wasm
-rwxr-xr-x 1 saumi saumi 162K Jan 17 00:43 client.wasm
-rwxr-xr-x 1 saumi saumi  70K Jan 17 00:43 server.wasm
```

On running the game no issues were noticed. 