### PR TITLE
explicitly specify build directory for compiling c3

### DIFF
--- a/build.js
+++ b/build.js
@@ -55,6 +55,7 @@ async function buildClient() {
         "-o", "client",
         "-z", "--export-table",
         "-z", "--allow-undefined",
+        "--build-dir", BUILD_FOLDER,
         SRC_FOLDER+"client.c3",
         SRC_FOLDER+"common.c3",
     ])
@@ -97,6 +98,7 @@ async function buildServer() {
         "compile",
         "-l", BUILD_FOLDER+"libcws.a",
         "-o", BUILD_FOLDER+"server",
+        "--build-dir", BUILD_FOLDER,
         BUILD_FOLDER+"server.o",
         SRC_FOLDER+"server.c3",
         SRC_FOLDER+"common.c3",


### PR DESCRIPTION
The default build directory was changed in [this](https://github.com/c3lang/c3c/commit/3da9f73338a8306f321b33676eaf1b953ec44600) commit, which caused an error when building this project. This PR adds flags to specify the build directory when compiling c3 files.