### PR TITLE
fix(readme): build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies
 
 ```console
 $ npm install
-$ node run build
+$ npm run build
 $ npm run serve
 $ <browser> https://localhost:6969/
 ```


### PR DESCRIPTION
Changed `node run build` to `npm run build`